### PR TITLE
Move more data into module data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ vendor/
 .yardwarns
 *.iml
 .*.sw?
+*~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,6 +4,10 @@ lookup_options:
   samba::shares_definitions:
     merge: hash
 
+samba::config_dir: '/etc/samba'
+samba::config_file: 'smb.conf'
+samba::global_config: {}
+samba::global_config_template: 'samba/global.erb'
 samba::package_ensure: 'present'
 samba::package_name: 'samba'
 samba::service_nmb_enable: false
@@ -12,3 +16,5 @@ samba::service_nmb_name: 'nmb'
 samba::service_smb_enable: true
 samba::service_smb_ensure: 'running'
 samba::service_smb_name: 'smb'
+samba::shares_definitions: {}
+samba::shares_template: 'samba/shares.erb'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,20 +19,20 @@
 # @param shares_template Specifies the template to use to construct the shares concat fragment.
 #
 class samba (
-  Stdlib::Absolutepath       $config_dir             = '/etc/samba',
-  String                     $config_file            = 'smb.conf',
-  Hash                       $global_config          = {},
-  String                     $global_config_template = 'samba/global.erb',
-  String                     $package_ensure         = 'present',
-  String                     $package_name           = 'samba',
-  Boolean                    $service_nmb_enable     = false,
-  Enum['running', 'stopped'] $service_nmb_ensure     = 'stopped',
-  String                     $service_nmb_name       = 'nmb',
-  Boolean                    $service_smb_enable     = true,
-  Enum['running', 'stopped'] $service_smb_ensure     = 'running',
-  String                     $service_smb_name       = 'smb',
-  Hash                       $shares_definitions     = {},
-  String                     $shares_template        = 'samba/shares.erb',
+  Stdlib::Absolutepath       $config_dir,
+  String                     $config_file,
+  Hash                       $global_config,
+  String                     $global_config_template,
+  String                     $package_ensure,
+  String                     $package_name,
+  Boolean                    $service_nmb_enable,
+  Enum['running', 'stopped'] $service_nmb_ensure,
+  String                     $service_nmb_name,
+  Boolean                    $service_smb_enable,
+  Enum['running', 'stopped'] $service_smb_ensure,
+  String                     $service_smb_name,
+  Hash                       $shares_definitions,
+  String                     $shares_template,
   ) {
   case $::operatingsystem {
     'RedHat', 'CentOS': {


### PR DESCRIPTION
This PR moves parameters out of the base class and fully into module data.

This is hopefully the first of a series of PRs adding FreeBSD support to the module.